### PR TITLE
Add toLowerCase to fixMac

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,7 @@ class ExampleDynamicPlatform implements DynamicPlatformPlugin {
 
     /** Because different sources use different characters for mac addresses. Now always use colon */
     fixMac(address?: string) {
-        return (address || '').replace(/-/g, ':').replace(/\./g, ':');
+        return (address || '').replace(/-/g, ':').replace(/\./g, ':').toLowerCase();
     }
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
[DylanPiercey/local-devices](https://github.com/DylanPiercey/local-devices) currently requires the MAC address to be lowercase. By adding `.toLowerCase()` to the end of the fixMac return we mitigate this issue.